### PR TITLE
basic gin recovery mw (rollbar + JSON errors)

### DIFF
--- a/gin_recovery.go
+++ b/gin_recovery.go
@@ -1,0 +1,184 @@
+package rex
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http/httputil"
+	"runtime"
+
+	"github.com/gin-gonic/gin"
+	"github.com/remerge/rex/rollbar"
+)
+
+var (
+	dunno     = []byte("???")
+	centerDot = []byte("·")
+	dot       = []byte(".")
+	slash     = []byte("/")
+)
+
+/**
+ * Custom gin recovery middleware that logs to both rollbar and the host
+ * service's logger. Most of the functionality is taken from the default Gin
+ * recovery middleware
+ */
+func NewGinRecovery(s *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			recoveredPanicErr := recover()
+
+			// Panic errors are special
+			if recoveredPanicErr != nil {
+				recoverFromPanickedGin(s, c, recoveredPanicErr)
+				return
+			}
+
+			// Look for any normal errors and ship them back if possible
+			errCount := len(c.Errors)
+
+			if errCount == 0 {
+				return
+			} else if errCount == 1 {
+				logGinError(s, c.Errors[0])
+
+				c.JSON(500, gin.H{
+					"error": c.Errors[0].Error(),
+				})
+
+				return
+			}
+
+			// Piece together multiple errors
+			errStrings := make([]string, errCount)
+
+			for i, err := range c.Errors {
+				errStrings[i] = err.Error()
+
+				logGinError(s, err)
+			}
+
+			c.JSON(500, gin.H{
+				"errors": errStrings,
+			})
+		}()
+
+		c.Next()
+	}
+}
+
+// Logs an error to both the service log and rollbar
+func logGinError(s *Service, err error) {
+	errStr := fmt.Sprintf("[gin recovery] %s", err.Error())
+
+	s.Log.Errorf(errStr)
+	rollbar.Error(rollbar.ERR, fmt.Errorf(errStr))
+}
+
+// Called when the gin recovery handler needs to deal with a panic (should not
+// be the usual case)
+func recoverFromPanickedGin(s *Service, c *gin.Context, recoveredPanicErr interface{}) {
+
+	// Get a nice stack trace and HTTP req dump
+	stack := getStackFrame(3)
+	httprequest, _ := httputil.DumpRequest(c.Request, false)
+
+	errStr := fmt.Sprintf(
+		"[gin recovery] panic recovered:\n%s\n%s\n%s",
+		string(httprequest),
+		recoveredPanicErr,
+		stack,
+	)
+
+	// Ship to rolllbar and anyone who cares
+	s.Log.Errorf(errStr)
+	rollbar.Error(rollbar.ERR, fmt.Errorf(errStr))
+
+	c.AbortWithStatus(500)
+}
+
+// Generates a nicely formated stack frame, skipping skip frames
+func getStackFrame(skip int) []byte {
+	buff := new(bytes.Buffer)
+
+	// As we loop, we open files and read them. These variables record the
+	// currently loaded file.
+	var lines [][]byte
+	var lastFile string
+
+	// Skip the expected number of frames
+	for i := skip; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+
+		// Couldn't recover anything, bail
+		if !ok {
+			break
+		}
+
+		// Print this much at least. If we can't find the source, it won't show.
+		fmt.Fprintf(buff, "%s:%d (0x%x)\n", file, line, pc)
+
+		// Grab line data if the target file has changed
+		if file != lastFile {
+			data, readErr := ioutil.ReadFile(file)
+
+			if readErr != nil {
+				continue
+			}
+
+			lines = bytes.Split(data, []byte{'\n'})
+			lastFile = file
+		}
+
+		fmt.Fprintf(
+			buff, "\t%s: %s\n",
+			pcFunctionName(pc),
+			trimmedSourceLine(lines, line),
+		)
+	}
+
+	return buff.Bytes()
+}
+
+// Attempts to return a space-trimmed version of the specific line in the
+// provided source. If the line is not found, a dummy placeholder is generated
+func trimmedSourceLine(lines [][]byte, n int) []byte {
+	n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
+
+	if n < 0 || n >= len(lines) {
+		return dunno
+	}
+
+	return bytes.TrimSpace(lines[n])
+}
+
+// Returns, if possible, the name of the function containing the PC
+func pcFunctionName(pc uintptr) []byte {
+	fn := runtime.FuncForPC(pc)
+
+	if fn == nil {
+		return dunno
+	}
+
+	name := []byte(fn.Name())
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//	runtime/debug.*T·ptrmethod
+	// and want
+	//	*T.ptrmethod
+	// Also the package path might contains dot (e.g. code.google.com/...),
+	// so first eliminate the path prefix
+	if lastslash := bytes.LastIndex(name, slash); lastslash >= 0 {
+		name = name[(lastslash + 1):]
+	}
+
+	if period := bytes.Index(name, dot); period >= 0 {
+		name = name[(period + 1):]
+	}
+
+	name = bytes.Replace(name, centerDot, dot, -1)
+
+	return name
+}

--- a/gin_recovery.go
+++ b/gin_recovery.go
@@ -1,184 +1,41 @@
 package rex
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"net/http/httputil"
-	"runtime"
 
 	"github.com/gin-gonic/gin"
 	"github.com/remerge/rex/rollbar"
 )
 
-var (
-	dunno     = []byte("???")
-	centerDot = []byte("·")
-	dot       = []byte(".")
-	slash     = []byte("/")
-)
-
 /**
  * Custom gin recovery middleware that logs to both rollbar and the host
- * service's logger. Most of the functionality is taken from the default Gin
- * recovery middleware
+ * service's logger.
  */
-func NewGinRecovery(s *Service) gin.HandlerFunc {
+func GinRecovery() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {
-			recoveredPanicErr := recover()
+			if err := recover(); err != nil {
+				switch err.(type) {
+				case error:
+					c.Error(err.(error))
+				default:
+					c.Error(fmt.Errorf("unknown error: %v", err))
+				}
+			}
 
-			// Panic errors are special
-			if recoveredPanicErr != nil {
-				recoverFromPanickedGin(s, c, recoveredPanicErr)
+			if len(c.Errors) == 0 {
 				return
 			}
 
-			// Look for any normal errors and ship them back if possible
-			errCount := len(c.Errors)
-
-			if errCount == 0 {
-				return
-			} else if errCount == 1 {
-				logGinError(s, c.Errors[0])
-
-				c.JSON(500, gin.H{
-					"error": c.Errors[0].Error(),
-				})
-
-				return
-			}
-
-			// Piece together multiple errors
-			errStrings := make([]string, errCount)
-
-			for i, err := range c.Errors {
-				errStrings[i] = err.Error()
-
-				logGinError(s, err)
+			for _, err := range c.Errors {
+				rollbar.RequestErrorWithStackSkip(rollbar.ERR, c.Request, err, 3)
 			}
 
 			c.JSON(500, gin.H{
-				"errors": errStrings,
+				"errors": c.Errors,
 			})
 		}()
 
 		c.Next()
 	}
-}
-
-// Logs an error to both the service log and rollbar
-func logGinError(s *Service, err error) {
-	errStr := fmt.Sprintf("[gin recovery] %s", err.Error())
-
-	s.Log.Errorf(errStr)
-	rollbar.Error(rollbar.ERR, fmt.Errorf(errStr))
-}
-
-// Called when the gin recovery handler needs to deal with a panic (should not
-// be the usual case)
-func recoverFromPanickedGin(s *Service, c *gin.Context, recoveredPanicErr interface{}) {
-
-	// Get a nice stack trace and HTTP req dump
-	stack := getStackFrame(3)
-	httprequest, _ := httputil.DumpRequest(c.Request, false)
-
-	errStr := fmt.Sprintf(
-		"[gin recovery] panic recovered:\n%s\n%s\n%s",
-		string(httprequest),
-		recoveredPanicErr,
-		stack,
-	)
-
-	// Ship to rolllbar and anyone who cares
-	s.Log.Errorf(errStr)
-	rollbar.Error(rollbar.ERR, fmt.Errorf(errStr))
-
-	c.AbortWithStatus(500)
-}
-
-// Generates a nicely formated stack frame, skipping skip frames
-func getStackFrame(skip int) []byte {
-	buff := new(bytes.Buffer)
-
-	// As we loop, we open files and read them. These variables record the
-	// currently loaded file.
-	var lines [][]byte
-	var lastFile string
-
-	// Skip the expected number of frames
-	for i := skip; ; i++ {
-		pc, file, line, ok := runtime.Caller(i)
-
-		// Couldn't recover anything, bail
-		if !ok {
-			break
-		}
-
-		// Print this much at least. If we can't find the source, it won't show.
-		fmt.Fprintf(buff, "%s:%d (0x%x)\n", file, line, pc)
-
-		// Grab line data if the target file has changed
-		if file != lastFile {
-			data, readErr := ioutil.ReadFile(file)
-
-			if readErr != nil {
-				continue
-			}
-
-			lines = bytes.Split(data, []byte{'\n'})
-			lastFile = file
-		}
-
-		fmt.Fprintf(
-			buff, "\t%s: %s\n",
-			pcFunctionName(pc),
-			trimmedSourceLine(lines, line),
-		)
-	}
-
-	return buff.Bytes()
-}
-
-// Attempts to return a space-trimmed version of the specific line in the
-// provided source. If the line is not found, a dummy placeholder is generated
-func trimmedSourceLine(lines [][]byte, n int) []byte {
-	n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
-
-	if n < 0 || n >= len(lines) {
-		return dunno
-	}
-
-	return bytes.TrimSpace(lines[n])
-}
-
-// Returns, if possible, the name of the function containing the PC
-func pcFunctionName(pc uintptr) []byte {
-	fn := runtime.FuncForPC(pc)
-
-	if fn == nil {
-		return dunno
-	}
-
-	name := []byte(fn.Name())
-
-	// The name includes the path name to the package, which is unnecessary
-	// since the file name is already included.  Plus, it has center dots.
-	// That is, we see
-	//	runtime/debug.*T·ptrmethod
-	// and want
-	//	*T.ptrmethod
-	// Also the package path might contains dot (e.g. code.google.com/...),
-	// so first eliminate the path prefix
-	if lastslash := bytes.LastIndex(name, slash); lastslash >= 0 {
-		name = name[(lastslash + 1):]
-	}
-
-	if period := bytes.Index(name, dot); period >= 0 {
-		name = name[(period + 1):]
-	}
-
-	name = bytes.Replace(name, centerDot, dot, -1)
-
-	return name
 }

--- a/rollbar/stack.go
+++ b/rollbar/stack.go
@@ -1,9 +1,18 @@
 package rollbar
 
 import (
-	"os"
+	"bytes"
+	"fmt"
+	"io/ioutil"
 	"runtime"
 	"strings"
+)
+
+var (
+	dunno     = []byte("???")
+	centerDot = []byte("·")
+	dot       = []byte(".")
+	slash     = []byte("/")
 )
 
 var (
@@ -16,26 +25,62 @@ var (
 )
 
 type Frame struct {
-	Filename string `json:"filename"`
-	Method   string `json:"method"`
-	Line     int    `json:"lineno"`
+	Filename   string `json:"filename"`
+	Method     string `json:"method"`
+	SourceLine string `json:"-"`
+	Line       int    `json:"lineno"`
+}
+
+func (frame Frame) String() string {
+	return fmt.Sprintf("  %s:%d\n\t%s: %s", frame.Filename, frame.Line, frame.Method, frame.SourceLine)
 }
 
 type Stack []Frame
 
 func BuildStack(skip int) Stack {
+	var lines [][]byte
+	var lastFile string
+
 	stack := make(Stack, 0)
 
 	for i := skip; ; i++ {
 		pc, file, line, ok := runtime.Caller(i)
+
 		if !ok {
 			break
 		}
-		file = shortenFilePath(file)
-		stack = append(stack, Frame{file, functionName(pc), line})
+
+		// Grab line data if the target file has changed
+		if file != lastFile {
+			data, readErr := ioutil.ReadFile(file)
+
+			if readErr != nil {
+				continue
+			}
+
+			lines = bytes.Split(data, []byte{'\n'})
+			lastFile = file
+		}
+
+		stack = append(stack, Frame{
+			shortenFilePath(file),
+			string(functionName(pc)),
+			string(trimmedSourceLine(lines, line)),
+			line,
+		})
 	}
 
 	return stack
+}
+
+func (stack Stack) String() (s string) {
+	frames := make([]string, 0)
+
+	for _, frame := range stack {
+		frames = append(frames, frame.String())
+	}
+
+	return strings.Join(frames, "\n")
 }
 
 // Remove un-needed information from the source file path. This makes them
@@ -46,25 +91,59 @@ func BuildStack(skip int) Stack {
 //   /usr/local/go/src/pkg/runtime/proc.c -> pkg/runtime/proc.c
 //   /home/foo/go/src/github.com/rollbar/rollbar.go -> github.com/rollbar/rollbar.go
 func shortenFilePath(s string) string {
-	idx := strings.Index(s, "/src/pkg/")
+	idx := strings.Index(s, "/src/")
 	if idx != -1 {
 		return s[idx+5:]
 	}
+
 	for _, pattern := range knownFilePathPatterns {
 		idx = strings.Index(s, pattern)
 		if idx != -1 {
 			return s[idx:]
 		}
 	}
+
 	return s
 }
 
-func functionName(pc uintptr) string {
-	fn := runtime.FuncForPC(pc)
-	if fn == nil {
-		return "???"
+// Attempts to return a space-trimmed version of the specific line in the
+// provided source. If the line is not found, a dummy placeholder is generated
+func trimmedSourceLine(lines [][]byte, n int) []byte {
+	n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
+
+	if n < 0 || n >= len(lines) {
+		return dunno
 	}
-	name := fn.Name()
-	end := strings.LastIndex(name, string(os.PathSeparator))
-	return name[end+1:]
+
+	return bytes.TrimSpace(lines[n])
+}
+
+func functionName(pc uintptr) []byte {
+	fn := runtime.FuncForPC(pc)
+
+	if fn == nil {
+		return dunno
+	}
+
+	name := []byte(fn.Name())
+
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//	runtime/debug.*T·ptrmethod
+	// and want
+	//	*T.ptrmethod
+	// Also the package path might contains dot (e.g. code.google.com/...),
+	// so first eliminate the path prefix
+	if lastslash := bytes.LastIndex(name, slash); lastslash >= 0 {
+		name = name[(lastslash + 1):]
+	}
+
+	if period := bytes.Index(name, dot); period >= 0 {
+		name = name[(period + 1):]
+	}
+
+	name = bytes.Replace(name, centerDot, dot, -1)
+
+	return name
 }

--- a/service.go
+++ b/service.go
@@ -117,14 +117,10 @@ func (service *Service) InitDefaultFlags() {
 }
 
 func (service *Service) InitEngine() {
-	if service.GinRecovery == nil {
-		service.GinRecovery = NewGinRecovery(service)
-	}
-
 	if service.Engine == nil {
 		service.Engine = gin.New()
 		service.Engine.Use(
-			service.GinRecovery,
+			GinRecovery(),
 			GinLogger(fmt.Sprintf("%s.engine", service.BaseConfig.Service)),
 		)
 	}
@@ -132,7 +128,7 @@ func (service *Service) InitEngine() {
 	if service.DebugEngine == nil {
 		service.DebugEngine = gin.New()
 		service.DebugEngine.Use(
-			service.GinRecovery,
+			GinRecovery(),
 			GinLogger(fmt.Sprintf("%s.debug", service.BaseConfig.Service)),
 		)
 	}
@@ -281,6 +277,10 @@ func (service *Service) ServeDebug() {
 		}
 		runtime.SetBlockProfileRate(r)
 		c.String(http.StatusOK, "new rate %d", r)
+	})
+
+	service.DebugEngine.GET("/panic", func(c *gin.Context) {
+		panic(fmt.Errorf("test panic"))
 	})
 
 	service.DebugServer = &graceful.Server{

--- a/service.go
+++ b/service.go
@@ -73,6 +73,7 @@ type Service struct {
 	TlsServer     *graceful.Server
 	DebugEngine   *gin.Engine
 	DebugServer   *graceful.Server
+	GinRecovery   gin.HandlerFunc
 }
 
 func (service *Service) InitLogger() {
@@ -116,14 +117,24 @@ func (service *Service) InitDefaultFlags() {
 }
 
 func (service *Service) InitEngine() {
+	if service.GinRecovery == nil {
+		service.GinRecovery = NewGinRecovery(service)
+	}
+
 	if service.Engine == nil {
 		service.Engine = gin.New()
-		service.Engine.Use(gin.Recovery(), GinLogger(fmt.Sprintf("%s.engine", service.BaseConfig.Service)))
+		service.Engine.Use(
+			service.GinRecovery,
+			GinLogger(fmt.Sprintf("%s.engine", service.BaseConfig.Service)),
+		)
 	}
 
 	if service.DebugEngine == nil {
 		service.DebugEngine = gin.New()
-		service.DebugEngine.Use(gin.Recovery(), GinLogger(fmt.Sprintf("%s.debug", service.BaseConfig.Service)))
+		service.DebugEngine.Use(
+			service.GinRecovery,
+			GinLogger(fmt.Sprintf("%s.debug", service.BaseConfig.Service)),
+		)
 	}
 }
 


### PR DESCRIPTION
This could use some improvement in the way of better non-panic error traces; afaik we would need to replace `c.Error` with something that can pick up traces the same way the default gin recovery middleware does. If anyone is in agreement, I'll also ship a `c.TracedError()` (in reference to the mostly useless rollbar error traces this generates)

The bulk of this was taken from https://github.com/gin-gonic/gin/blob/develop/recovery.go