### PR TITLE
add CompositeError method, useful in defer blocks

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,6 +6,24 @@ import (
 	"github.com/remerge/rex/rollbar"
 )
 
+// Returns a multi-line error containing all of the supplied errors, with nil
+// values excluded
+func CompositeError(errors ...error) error {
+	finalErrorString := ""
+
+	for i := 0; i < len(errors); i++ {
+		if errors[i] != nil {
+			if len(finalErrorString) > 0 {
+				finalErrorString += "\n"
+			}
+
+			finalErrorString += errors[i].Error()
+		}
+	}
+
+	return fmt.Errorf(finalErrorString)
+}
+
 func MayPanic(err error) {
 	if err != nil {
 		rollbar.Error(rollbar.CRIT, err)


### PR DESCRIPTION
Allows one to do:

```
func /*....*/ (err error) {
//...
err = os.Create(/*...*/)
defer err = rex.CompositeError(err, os.Remove(/*...*/))
//...

return
}
```