### PR TITLE
moved dynamic data in rollbar error text to rollbar.Field

### DIFF
--- a/server/connection.go
+++ b/server/connection.go
@@ -118,12 +118,13 @@ func (c *Connection) Serve() {
 					},
 				})
 			default:
-				rollbar.Message(rollbar.CRIT, fmt.Sprintf("unhandled error: %v", err), &rollbar.Field{
-					Name: "person",
-					Data: map[string]string{
+				rollbar.Message(rollbar.CRIT,
+					"unhandled server connection error",
+					&rollbar.Field{Name: "error", Data: err},
+					&rollbar.Field{Name: "person", Data: map[string]string{
 						"id": c.Conn.RemoteAddr().String(),
-					},
-				})
+					}},
+				)
 			}
 		}
 		c.Close()


### PR DESCRIPTION
https://trello.com/c/GQBcWuij/1242-change-rollbar-error-messages-to-static-by-using-meta-data