### PR TITLE
split loadsaver interface, create 1 pair per worker

### DIFF
--- a/kafka/group_processor.go
+++ b/kafka/group_processor.go
@@ -251,7 +251,7 @@ func (gp *GroupProcessor) Close() {
 	// terminate workers/savers
 	gp.log.Infof("closing save workers")
 	gp.saveWorkerDone.Close(gp.Config.NumSaveWorker)
-	gp.log.Infof("closing closing savers")
+	gp.log.Infof("closing savers")
 	for i := 0; i < gp.Config.NumSaveWorker; i++ {
 		gp.savers[i].Close()
 	}


### PR DESCRIPTION
`LoadSaver` was a bit restrictive before, wasn't suitable for bulk saving. cc: @dynamix
