### PR TITLE
change flush frequency

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -64,7 +64,7 @@ func (client *Client) NewFastProducer(cb ProducerErrorCallback) (*Producer, erro
 	config.Producer.RequiredAcks = sarama.NoResponse
 	config.ChannelBufferSize = 131072 // buffer 128k messages
 	if os.Getenv("REX_ENV") != "development" {
-		config.Producer.Flush.Frequency = 1 * time.Second
+		config.Producer.Flush.Frequency = 300 * time.Millisecond
 	}
 	return client.NewProducer("fast", config, cb)
 }


### PR DESCRIPTION
https://trello.com/c/jWlqSUUs/3235-investigate-maximum-request-accumulated-waiting-for-space-messages-from-act

So following happens:

    Act is using rex
    rex has flush frequency 1 second https://github.com/remerge/rex/blob/538e3e8ad00833e5fb37478ddf45003469a9e367/kafka/producer.go#L67
    sarama has internal buffer that is flushed and send to kafka every second
    Buffer has max size, and sometimes this is filled before 1 second
    In this case - we have this message in log and flush the buffer.
    Imho we do not loose any message, but could be that we do not process some messages for a short period of time

Simplest solution - imho - change flush frequency in rex
