### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -41,7 +41,7 @@ type BackoffDuration struct {
 	Min, Max time.Duration
 }
 
-// Returns the current value of the counter and then
+// Duration returns the current value of the counter and then
 // multiplies it Factor
 func (b *BackoffDuration) Duration() time.Duration {
 	// Zero-values are nonsensical, so we use

--- a/service/metrics.go
+++ b/service/metrics.go
@@ -57,7 +57,7 @@ var (
 	threadCreateProfile = pprof.Lookup("threadcreate")
 )
 
-// Capture new values for the Go runtime statistics exported in
+// CaptureRuntimeMemStats captures new values for the Go runtime statistics exported in
 // runtime.MemStats.  This is designed to be called as a goroutine.
 func CaptureRuntimeMemStats(r metrics.Registry, d time.Duration) {
 	for range time.Tick(d) {
@@ -65,7 +65,7 @@ func CaptureRuntimeMemStats(r metrics.Registry, d time.Duration) {
 	}
 }
 
-// Capture new values for the Go runtime statistics exported in
+// CaptureRuntimeMemStatsOnce captures new values for the Go runtime statistics exported in
 // runtime.MemStats.  This is designed to be called in a background
 // goroutine.  Giving a registry which has not been given to
 // RegisterRuntimeMemStats will panic.

--- a/string.go
+++ b/string.go
@@ -4,7 +4,7 @@ import "bytes"
 
 // from - https://github.com/kennygrant/sanitize/blob/master/sanitize.go
 
-// Replace a set of accented characters with ascii equivalents.
+// RemoveAccents replaces a set of accented characters with ascii equivalents.
 func RemoveAccents(text string) string {
 	// Replace some common accent characters
 	b := bytes.NewBufferString("")

--- a/strings.go
+++ b/strings.go
@@ -105,7 +105,7 @@ func (rcv Strings) IsSortedBy(less func(string, string) bool) bool {
 	return true
 }
 
-// IsSortedDesc reports whether an instance of Strings is sorted in descending order, using the pass func to define ‘less’. See: http://clipperhouse.github.io/gen/#SortBy
+// IsSortedByDesc reports whether an instance of Strings is sorted in descending order, using the pass func to define ‘less’. See: http://clipperhouse.github.io/gen/#SortBy
 func (rcv Strings) IsSortedByDesc(less func(string, string) bool) bool {
 	greater := func(a, b string) bool {
 		return a != b && !less(a, b)
@@ -392,7 +392,7 @@ func NewStringSetFromSlice(s []string) StringSet {
 	return a
 }
 
-// Adds an item to the current set if it doesn't already exist in the set.
+// Add adds an item to the current set if it doesn't already exist in the set.
 func (set StringSet) Add(i string) bool {
 	_, found := set[i]
 	set[i] = struct{}{}
@@ -429,7 +429,7 @@ func (set StringSet) IsSuperset(other StringSet) bool {
 	return other.IsSubset(set)
 }
 
-// Returns a new set with all items in both sets.
+// Union returns a new set with all items in both sets.
 func (set StringSet) Union(other StringSet) StringSet {
 	unionedSet := NewStringSet()
 
@@ -442,7 +442,7 @@ func (set StringSet) Union(other StringSet) StringSet {
 	return unionedSet
 }
 
-// Returns a new set with items that exist only in both sets.
+// Intersect returns a new set with items that exist only in both sets.
 func (set StringSet) Intersect(other StringSet) StringSet {
 	intersection := NewStringSet()
 	// loop over smaller set
@@ -462,7 +462,7 @@ func (set StringSet) Intersect(other StringSet) StringSet {
 	return intersection
 }
 
-// Returns a new set with items in the current set but not in the other set
+// Difference returns a new set with items in the current set but not in the other set
 func (set StringSet) Difference(other StringSet) StringSet {
 	differencedSet := NewStringSet()
 	for elem := range set {
@@ -473,14 +473,14 @@ func (set StringSet) Difference(other StringSet) StringSet {
 	return differencedSet
 }
 
-// Returns a new set with items in the current set or the other set but not in both.
+// SymmetricDifference returns a new set with items in the current set or the other set but not in both.
 func (set StringSet) SymmetricDifference(other StringSet) StringSet {
 	aDiff := set.Difference(other)
 	bDiff := other.Difference(set)
 	return aDiff.Union(bDiff)
 }
 
-// Clears the entire set to be the empty set.
+// Clear clears the entire set to be the empty set.
 func (set *StringSet) Clear() {
 	*set = make(StringSet)
 }
@@ -523,7 +523,7 @@ func (set StringSet) Equal(other StringSet) bool {
 	return true
 }
 
-// Returns a clone of the set.
+// Clone returns a clone of the set.
 // Does NOT clone the underlying elements.
 func (set StringSet) Clone() StringSet {
 	clonedSet := NewStringSet()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?