### PR TITLE
[3090] increase retry config values for safe producer

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -72,6 +72,8 @@ func (client *Client) NewFastProducer(cb ProducerErrorCallback) (*Producer, erro
 func (client *Client) NewSafeProducer() (*Producer, error) {
 	config := sarama.NewConfig()
 	config.Producer.Compression = sarama.CompressionSnappy
+	config.Producer.Retry.Max = 10
+	config.Producer.Retry.Backoff = 200 * time.Millisecond
 	config.Producer.Return.Successes = true
 	config.Producer.Return.Errors = true
 	config.Producer.RequiredAcks = sarama.WaitForLocal


### PR DESCRIPTION
# Purpose

[Trello card](https://trello.com/c/lygh5IkM/3090-investigate-temporary-kafka-produce-errors-act-trigger)

Let's try to increase both number of retries and backoff time and see if it will be enough to sustain kafka rebalancing.